### PR TITLE
Update core.py

### DIFF
--- a/distributed_hetero_ml/core.py
+++ b/distributed_hetero_ml/core.py
@@ -98,7 +98,7 @@ class DistributedTrainer:
             for iteration in range(num_iterations):
                 logger.info(f"\n--- Iteration {iteration + 1}/{num_iterations} ---")
 
-                step_start = time.time()
+                step_start = time.perf_counter()
                 futures = [worker.train_step.remote(self.parameter_server) for worker in self.workers]
 
                 results = ray.get(futures)
@@ -131,7 +131,7 @@ class DistributedTrainer:
 
     def _calculate_iteration_metrics(self, results: list[TrainingResult], ps_metrics: dict[str, float], step_start: float) -> dict[str, Any]:
         """Calculate metrics for current iteration."""
-        total_step_time = time.time() - step_start
+        total_step_time = time.perf_counter() - step_start
 
         total_loss = sum(r.loss for r in results)
         avg_loss = total_loss / len(results)


### PR DESCRIPTION
Replace calls to `time.time()` with `time.perf_counter()`


## Copilot Summary

This pull request updates the timing mechanism in the `train` method of the `distributed_hetero_ml/core.py` file to improve the accuracy of time measurements by switching from `time.time()` to `time.perf_counter()`.

### Timing mechanism update:

* Replaced `time.time()` with `time.perf_counter()` for measuring the start of each training step, ensuring higher precision for elapsed time calculations. (`distributed_hetero_ml/core.py`, [distributed_hetero_ml/core.pyL101-R101](diffhunk://#diff-df4eb7057e575f6c3cf5d7b88949e94b4b20791a7b6ad14c1144900f1c7af76eL101-R101))
* Updated the calculation of `total_step_time` to use `time.perf_counter()` for more accurate iteration timing. (`distributed_hetero_ml/core.py`, [distributed_hetero_ml/core.pyL134-R134](diffhunk://#diff-df4eb7057e575f6c3cf5d7b88949e94b4b20791a7b6ad14c1144900f1c7af76eL134-R134))